### PR TITLE
fix: Pin flake to stable nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,15 +227,17 @@
     "nixNeovim": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixvim": "nixvim"
       },
       "locked": {
-        "lastModified": 1732100880,
-        "narHash": "sha256-gguHjGCAAhQaZpRSQiAp+c6NS0JMZ55c+1H/gV4Gtnw=",
+        "lastModified": 1734020378,
+        "narHash": "sha256-aMMspkboPtAI2cHEzqYnuLE35wsL69I+gCIg72WOYHQ=",
         "owner": "D3vZro",
         "repo": "NixNeovim",
-        "rev": "28e0689c6efd8f46a6c246a7384b353d8cbd1bf3",
+        "rev": "e17b25d2ae09e14387453d8968d66f6dbcc03abf",
         "type": "github"
       },
       "original": {
@@ -248,13 +250,13 @@
       "locked": {
         "lastModified": 1730785428,
         "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
-        "owner": "nixos",
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -274,29 +276,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730785428,
-        "narHash": "sha256-Zwl8YgTVJTEum+L+0zVAWvXAGbWAuXHax3KzuejaDyo=",
+        "lastModified": 1734323986,
+        "narHash": "sha256-m/lh6hYMIWDYHCAsn81CDAiXoT3gmxXI9J987W5tZrE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4aa36568d413aca0ea84a1684d2d46f55dbabad7",
+        "rev": "394571358ce82dff7411395829aa6a3aad45b907",
         "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
-        "path": "/nix/store/h5v6brw3yj14b52a58imzjm3mid6scsz-source",
-        "type": "path"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-24.11",
         "type": "indirect"
       }
     },
@@ -308,7 +297,7 @@
         "git-hooks": "git-hooks",
         "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "nuschtosSearch": "nuschtosSearch",
         "treefmt-nix": "treefmt-nix"
       },
@@ -353,7 +342,7 @@
     "root": {
       "inputs": {
         "nixNeovim": "nixNeovim",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,12 @@
   description = "A specialized devshell for C++ projects";
 
   inputs = {
-    nixpkgs.url = "nixpkgs";
-    nixNeovim.url = "github:D3vZro/NixNeovim";
+    nixpkgs.url = "nixpkgs/nixos-24.11";
+
+    nixNeovim =  {
+      url = "github:D3vZro/NixNeovim";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs = { self, nixpkgs, nixNeovim,... }:
@@ -20,8 +24,8 @@
           # Editor
           nvim
           svelte-language-server
-          tailwindcss-language-server
           typescript-language-server
+          tailwindcss-language-server
 
           # Utils
           hexedit

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "A specialized devshell for C++ projects";
+  description = "A specialized devshell for Svelte + TailwindCSS";
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-24.11";
@@ -24,8 +24,8 @@
           # Editor
           nvim
           svelte-language-server
-          typescript-language-server
           tailwindcss-language-server
+          typescript-language-server
 
           # Utils
           hexedit


### PR DESCRIPTION
Using `nixpkgs-unstable` breaks things in unexpected ways. This PR pins the package source on a stable release.