### PR TITLE
fix: Resolve vite version mismatch

### DIFF
--- a/visual-debugger/package.json
+++ b/visual-debugger/package.json
@@ -25,5 +25,10 @@
 		"vitest": "^2.0.4",
 		"@types/fs-extra": "^11.0.4",
 		"axios": "^1.7.9"
-	}
+	},
+        "overrides": {
+                "vitest": {
+                        "vite": "^6.0.0"
+                }
+        }
 }


### PR DESCRIPTION
This PR fixes a version conflict related to `vitest`'s dependency on `vite` and the project dependency `vite`, resolving the failing check `vdb-check` in the CI.