### PR TITLE
chore: cleanup parsing of queries

### DIFF
--- a/visual-debugger/src/data-processing/queryBuild.ts
+++ b/visual-debugger/src/data-processing/queryBuild.ts
@@ -1,17 +1,11 @@
 import axios from "axios";
-import {queryJsonStringStore, interpolatedQueryStore} from "../sveltestore";
+import {interpolatedQueryStore} from "../sveltestore";
 import type {Location, Batch} from "./parsing-types/queryInterpolationTypes.ts"
-
 
 /**
  * Base URL of the MOTIS API
  */
 const motisApiUrlBase = 'http://localhost:8080/api/v1/'
-
-/**
- * Attribute used for storing the content of the query file
- */
-let queryFileContent: string
 
 /**
  * Reads the query batch and generates the nearest stops for the read query trips
@@ -59,16 +53,10 @@ async function computeLocationId(locationName: string) {
 /**
  * Interaction method for printing queries to page
  */
-export function computeQueryAttributes() {
-
-    //get read file content from storage
-    queryJsonStringStore.subscribe(file_data => {
-        queryFileContent = file_data;
-    })
-
+export function computeQueryAttributes(queryString:string) {
     try {
         // find next stops for all queries
-        buildQueryDataset(queryFileContent)
+        buildQueryDataset(queryString)
     } catch (err) {
         console.log(err)
     }

--- a/visual-debugger/src/lib/components/ui/upload/DefaultPlanUpload.svelte
+++ b/visual-debugger/src/lib/components/ui/upload/DefaultPlanUpload.svelte
@@ -25,11 +25,5 @@
 </script>
 
 <div>
-    
     <Input id="q-upload" type="file" on:change={putFileIntoStorage} />
-    
-    <!-- <input type="file" on:change={putFileIntoStorage} class=""/>
-    {#if file}
-        <p>Selected file: {file.name}</p>
-    {/if} -->
 </div>

--- a/visual-debugger/src/lib/components/ui/upload/QueryUpload.svelte
+++ b/visual-debugger/src/lib/components/ui/upload/QueryUpload.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
-    import {queryJsonStringStore} from "../../../../sveltestore.ts";
     import {computeQueryAttributes} from "../../../../data-processing/queryBuild.ts";
-    import { Input } from "$lib/components/ui/input/index.js";
+    import {Input} from "$lib/components/ui/input/index.js";
 
     let file: File | null = null;
-
-    // When file was first uploaded, parse and interpolate the queries
-    $: if (!($queryJsonStringStore == "DEFAULT")) {
-        computeQueryAttributes()
-    }
 
     /**
      * Gets the uploaded file and puts its content into the svelte store
@@ -20,17 +14,12 @@
 
         // put content of read file as string into storage
         file?.text().then((file_content_string) => {
-                queryJsonStringStore.set(file_content_string);
+                computeQueryAttributes(file_content_string);
             }
         )
-
     };
 </script>
 
 <div>
-    <Input id="q-upload" type="file" on:change={putFileIntoStorage} />
-    <!-- <input type="file" on:change={putFileIntoStorage}/>
-    {#if file}
-        <p>Selected file: {file.name}</p>
-    {/if} -->
+    <Input id="q-upload" type="file" on:change={putFileIntoStorage}/>
 </div>

--- a/visual-debugger/src/sveltestore.ts
+++ b/visual-debugger/src/sveltestore.ts
@@ -2,12 +2,6 @@ import {writable} from "svelte/store";
 import {Query} from "./data-processing/parsing-types/queryInterpolationTypes.ts";
 import {Plan} from "./data-processing/parsing-types/planParsingTypes.ts";
 
-
-/**
- * Storage for content of query batch json file
- */
-export const queryJsonStringStore = writable<string>("DEFAULT")
-
 /**
  * Storage for interpolated queries
  */


### PR DESCRIPTION
<!-- List of changes as bullet points or free form text -->
- Deleted jsonQueryStringStore
- changed signature for method "computeQueryAttributes" to allow for direct passing of string
- changed query upload so that file contents are computed directly instead of being passed through useless store

Closes #39


## Checklist

#### Formalities:
- [x] PR targets `staging`, if compare branch is `chore/*` or `feat/*`
- [x] PR title is formatted as a [commit](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] New functions are commented in the source file
- [ ] ~~Notes are added to wiki~~

#### Quality assurance:
- Manual build and unit/component testing:
    - [x] Linux
    - [x] MacOS
    - [ ] Windows
- Manual End-To-End testing:
    - [x] Upload of query batch
    - [x] Computation of routing results
    - [x] Download plan
    - [x] Upload plan
    - [x] Compare functionality

#### For `staging -> master`
- [ ] ~~Check for relevant open issues~~
- [ ] ~~After merge: Create release~~

---
