### PR TITLE
fix: unequal number of attributes

### DIFF
--- a/visual-debugger/assets/Query-Batch.json
+++ b/visual-debugger/assets/Query-Batch.json
@@ -16,8 +16,8 @@
     },
     {
       "index": 2,
-      "from": "Aachen Bushof",
-      "to": "Aachen Schanz",
+      "from": "Aachen Luisenhospital",
+      "to": "Euskirchen, Bf",
       "class": "Regional",
       "time": "2025-02-20T10:00:00Z"
     }

--- a/visual-debugger/assets/default-plan-mismatched.json
+++ b/visual-debugger/assets/default-plan-mismatched.json
@@ -67,7 +67,7 @@
               "scheduledArrival": "2025-02-20T10:07:00Z",
               "vertexType": "TRANSIT"
             },
-            "duration": 300,
+            "duration": 30000,
             "startTime": "2025-02-20T10:02:00Z",
             "endTime": "2025-02-20T10:07:00Z",
             "scheduledStartTime": "2025-02-20T10:02:00Z",
@@ -2951,7 +2951,7 @@
         "duration": 240,
         "startTime": "2025-02-20T10:08:00Z",
         "endTime": "2025-02-20T10:12:00Z",
-        "transfers": 0,
+        "transfers": 1,
         "legs": [
           {
             "mode": "REGIONAL_RAIL",
@@ -2992,6 +2992,105 @@
             "legGeometry": {
               "points": "_|zpg]{sgxrBsN_cBbhAkk@ziB_eFrD{Y~k@wwAfw@_rBjf@knAfqCkqGboEcgIbbDg_GvgD_eFvzBwgD~jCw}CfqCcdCfJwGb[oPfqC_rBvzBwwA~eCg|@vmA{YvlDwj@fqCwGjmDjHz{Crb@~rD~nArwG~~C~xAbt@v`@zYnbAjk@jlGvgDbuBz|@bzBffArkCn}@n|Cz|@rpCn}@fqCrb@fkFffAb[?ve@vGbcKnZbaGwG~lG{OzbHct@~xAgYvzB_b@r~A{YnaD{|@~eCseAjlBsyAbBzm@fw@oPrrG{lCn{FglCn|CwzB~_Fw}CbbDocCzuFgyDreFs{E~_FshGbhA_rBj`CsxDniEcjJbuBwmFvmAwjE~xAseFvmA_eFvmAczGryA{rJnbAkaJ~k@w}Hb[wjEsD?rD?ja@knFzOglCzO__Djf@{bHb[{_GnPg|Eb[czLrDkqGsDcdCsIcdCkf@glHsq@cwF{aA{_GobAwjEgiBo`GooBwjEscBwgDo|CknFgvCosE{iBk{BksAsrBcmAwzBsxDcdHczBcwFsq@_rB_l@srBkk@wzBkf@k{Bsq@opDsDgY{bCcnRvcAnjG",
               "length": 106
+            }
+          },
+          {
+            "mode": "WALK",
+            "from": {
+              "name": "Aachen Hbf",
+              "stopId": "AVVGTFSMastenmitSPNV_000000607470",
+              "lat": 50.743024,
+              "lon": 6.602543,
+              "level": 0,
+              "arrival": "2025-02-20T18:35:00Z",
+              "departure": "2025-02-20T18:35:00Z",
+              "scheduledArrival": "2025-02-20T18:35:00Z",
+              "vertexType": "TRANSIT"
+            },
+            "to": {
+              "name": "Aachen Hbf",
+              "stopId": "AVVGTFSMastenmitSPNV_000000607470",
+              "lat": 50.743024,
+              "lon": 6.602543,
+              "level": 0,
+              "arrival": "2025-02-20T18:37:00Z",
+              "vertexType": "TRANSIT"
+            },
+            "duration": 120,
+            "startTime": "2025-02-20T18:35:00Z",
+            "endTime": "2025-02-20T18:37:00Z",
+            "scheduledStartTime": "1970-01-01T00:00:00Z",
+            "scheduledEndTime": "1970-01-01T00:00:00Z",
+            "realTime": false,
+            "legGeometry": {
+              "points": "",
+              "length": 0
+            }
+          },
+          {
+            "mode": "BUS",
+            "from": {
+              "name": "Aachen Hbf",
+              "stopId": "AVVGTFSMastenmitSPNV_000000607470",
+              "lat": 50.743024,
+              "lon": 6.602543,
+              "level": 0,
+              "departure": "2025-02-20T18:42:00Z",
+              "scheduledDeparture": "2025-02-20T18:42:00Z",
+              "vertexType": "TRANSIT"
+            },
+            "to": {
+              "name": "Euskirchen, Bf",
+              "stopId": "AVVGTFSMastenmitSPNV_000000308390",
+              "lat": 50.657759999999996,
+              "lon": 6.792193,
+              "level": 0,
+              "arrival": "2025-02-20T19:18:00Z",
+              "scheduledArrival": "2025-02-20T19:18:00Z",
+              "vertexType": "TRANSIT"
+            },
+            "duration": 2160,
+            "startTime": "2025-02-20T18:42:00Z",
+            "endTime": "2025-02-20T19:18:00Z",
+            "scheduledStartTime": "2025-02-20T18:42:00Z",
+            "scheduledEndTime": "2025-02-20T19:18:00Z",
+            "realTime": false,
+            "headsign": "Euskirchen, Bf",
+            "agencyName": "Rurtalbahn GmbH",
+            "agencyUrl": "https://www.rurtalbahn.de",
+            "agencyId": "106",
+            "tripId": "20250220_19:42_AVVGTFSMastenmitSPNV_450894220",
+            "routeShortName": "Bus RB28",
+            "source": "AVV_GTFS_Masten_mit_SPNV.zip/stop_times.txt:323944:323947",
+            "intermediateStops": [
+              {
+                "name": "Zülpich, Bahnhof",
+                "stopId": "AVVGTFSMastenmitSPNV_000000648590",
+                "lat": 50.69817400000001,
+                "lon": 6.662475999999999,
+                "level": 0,
+                "arrival": "2025-02-20T18:57:00Z",
+                "departure": "2025-02-20T18:57:00Z",
+                "scheduledArrival": "2025-02-20T18:57:00Z",
+                "scheduledDeparture": "2025-02-20T18:57:00Z",
+                "vertexType": "TRANSIT"
+              },
+              {
+                "name": "Nemmenich",
+                "stopId": "AVVGTFSMastenmitSPNV_000000654290",
+                "lat": 50.688051,
+                "lon": 6.681466,
+                "level": 0,
+                "arrival": "2025-02-20T19:02:00Z",
+                "departure": "2025-02-20T19:02:00Z",
+                "scheduledArrival": "2025-02-20T19:02:00Z",
+                "scheduledDeparture": "2025-02-20T19:02:00Z",
+                "vertexType": "TRANSIT"
+              }
+            ],
+            "legGeometry": {
+              "points": "_uazf]k|z||B_]sl@bQbVvhAkqBblNcgXblNgyXzio@winAfgdAs|pBbj^_{r@vucAkxoBnnOwcZv`O_lYnyj@obgAjoz@k}`Bv{l@oujAngs@wqtA~u^_ts@rpHoaNrcGcoJbzGkfJjjHk|IvpQoyQnbAg|@bpBoyBf_QkgQj_KsyKzqC_kCjuEg~Db}CkjCb_HoxEviHkfEf`IweEndEwfBboEk}AjhDccAreFstAncHsjAz{f@czGb|Fcy@j`Cw`@zvCc`@rkCoi@ryAw`@buBoi@vzBoi@rkC_{@j`C_{@vuBkdAv|F{qCffFg{Cv|F_gEndE_dDvbD{{CzqCwsCbxCwvDfaF{dG~mDgkFzlCccFftDk`H~xF{gMb}HsyPftDclIvgNoy[vcA{`DwcAz`DrvEwrKj}gA{rgCbbN{x[rcGwuL~aYo|p@bmgAcpiCgr@fgCvyTo_h@bxRwgq@br_@sknAfr@glC~nAc`E~nAoiEfi[kbcAnjQ_vm@~cN_jd@zdV{xy@vmPchi@vr_@ccqAn_^{ojAno[ojcAr~d@gc_BrqTc`w@f|c@g}wAbvIolZrIoZ~kEcbNz|^k}lAbyJo_c@zrE{`SnvKsmj@zdQcidAnpDonOn~y@svwEz}Q_xv@~~HocWv_MsdXbsa@ktz@nwHgfP~k@oPv}f@kbcAnmHsrVniE_lYve@c_WR_rB_g@ghTwy@skMgJgY_b^wn`C{kA{lHccKgeq@_kHgbf@ctEg_[cxCsxSojG{hc@wbDwmUswBcdMRwGsDwG?cQsDwG?wGsDoP?kH_DoPsDwG?cQsDwG?wGsDoP?wG_DcQsDwG?wGsDcQ?wGsDoP?kH_DoPsDwG?wGsDcQ?wGsDoP?kHsDwG_DoP?wGsDcQ?wGsDwG?oPsDkH_DoP?wGsDcQ?wGsDwG?cQ_DwGsDoP?wGsDkH?oPsDwG?cQ_DwG?oPsDwGsDkH?oPn{AflC",
+              "length": 177
             }
           }
         ],

--- a/visual-debugger/src/data-processing/compareObjects.ts
+++ b/visual-debugger/src/data-processing/compareObjects.ts
@@ -104,11 +104,18 @@ export function buildShadowOfItinerary() {
     })
 
     currentDefaultPlanStore.subscribe((data) => {
-        defaultItinerary = data.itineraries[itinerary.index]
+        //if current default plan has fewer elements than itinerary.index, build dummy object
+        if(itinerary.index > data.itineraries.length) {
+            defaultItinerary = new Itinerary()
+        }else {
+            defaultItinerary = data.itineraries[itinerary.index]
+        }
     })
+
     let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
     let shadow: ItineraryShadow = new ItineraryShadow(maxLegs)
 
+    //if itinerary has no counterpart, set all leg attributes to false
     if(itinerary.index > defaultItinerary.index) {
         setShadowLegFalse(shadow.legs)
         shadowItineraryStore.set(shadow)
@@ -118,8 +125,6 @@ export function buildShadowOfItinerary() {
     // gather the mismatched attributes
     let falseAttributes = compareItineraries(itinerary, defaultItinerary)
 
-
-
     Object.entries(shadow).forEach(([key]) => {
         // set all attributes except for "legs" to false if they are marked as mismatched
         if (!(key == "legs") && falseAttributes[0].includes(key)) {
@@ -127,7 +132,11 @@ export function buildShadowOfItinerary() {
             shadow[key as keyof ItineraryShadow] = false;
         }
         let minLegs = Math.min(itinerary.legs.length, defaultItinerary.legs.length)
-        setShadowLegFalse(shadow.legs.slice(minLegs, maxLegs))
+
+        // mark all excess legs as mismatched
+        if(minLegs != maxLegs){
+            setShadowLegFalse(shadow.legs.slice(minLegs, maxLegs))
+        }
 
         // build leg shadow objects
         if (key == "legs" && falseAttributes[0].includes("legs")) {
@@ -152,12 +161,20 @@ export function buildShadowOfDefaultItinerary() {
     })
 
     currentPlanStore.subscribe((data) => {
-        itinerary = data.itineraries[itinerary.index]
+        //if current plan has fewer elements than defaultItinerary.index, build dummy object
+        if(defaultItinerary.index>data.itineraries.length) {
+            itinerary = new Itinerary()
+        }
+        else {
+            itinerary = data.itineraries[defaultItinerary.index]
+        }
     })
 
-    let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
 
+    let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
     let shadow: ItineraryShadow = new ItineraryShadow(maxLegs)
+
+    //if defaultItinerary has no counterpart, set all leg attributes to false
     if(defaultItinerary.index > itinerary.index) {
         setShadowLegFalse(shadow.legs)
         defaultShadowItineraryStore.set(shadow)
@@ -174,7 +191,10 @@ export function buildShadowOfDefaultItinerary() {
             shadow[key as keyof ItineraryShadow] = false;
         }
         let minLegs = Math.min(itinerary.legs.length, defaultItinerary.legs.length)
-        setShadowLegFalse(shadow.legs.slice(minLegs, maxLegs))
+        //if leg count is different, set all attributes of excess legs to false
+        if(minLegs != maxLegs) {
+            setShadowLegFalse(shadow.legs.slice(minLegs, maxLegs))
+        }
 
         // build leg shadow objects
         if (key == "legs" && falseAttributes[0].includes("legs")) {

--- a/visual-debugger/src/data-processing/compareObjects.ts
+++ b/visual-debugger/src/data-processing/compareObjects.ts
@@ -106,12 +106,19 @@ export function buildShadowOfItinerary() {
     currentDefaultPlanStore.subscribe((data) => {
         defaultItinerary = data.itineraries[itinerary.index]
     })
+    let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
+    let shadow: ItineraryShadow = new ItineraryShadow(maxLegs)
+
+    if(itinerary.index > defaultItinerary.index) {
+        setShadowLegFalse(shadow.legs)
+        shadowItineraryStore.set(shadow)
+        return
+    }
 
     // gather the mismatched attributes
     let falseAttributes = compareItineraries(itinerary, defaultItinerary)
 
-    let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
-    let shadow: ItineraryShadow = new ItineraryShadow(maxLegs)
+
 
     Object.entries(shadow).forEach(([key]) => {
         // set all attributes except for "legs" to false if they are marked as mismatched
@@ -141,17 +148,24 @@ export function buildShadowOfDefaultItinerary() {
 
     // gets the itineraries from their stores
     currentDefaultItineraryStore.subscribe((data) => {
-        itinerary = data
+        defaultItinerary = data
     })
 
     currentPlanStore.subscribe((data) => {
-        defaultItinerary = data.itineraries[itinerary.index]
+        itinerary = data.itineraries[itinerary.index]
     })
 
-    let falseAttributes = compareItineraries(itinerary, defaultItinerary)
     let maxLegs = Math.max(defaultItinerary.legs.length, itinerary.legs.length)
 
     let shadow: ItineraryShadow = new ItineraryShadow(maxLegs)
+    if(defaultItinerary.index > itinerary.index) {
+        setShadowLegFalse(shadow.legs)
+        defaultShadowItineraryStore.set(shadow)
+        return
+    }
+
+    let falseAttributes = compareItineraries(itinerary, defaultItinerary)
+
 
     Object.entries(shadow).forEach(([key]) => {
         // set all attributes except for "legs" to false if they are marked as mismatched

--- a/visual-debugger/src/data-processing/comparePlans.ts
+++ b/visual-debugger/src/data-processing/comparePlans.ts
@@ -25,9 +25,10 @@ export function comparePlans() {
     defaultPlanDatasetStore.subscribe(data => {
         defaultPlans = data
     })
+    let minLegs=Math.min(plans.length, defaultPlans.length)
 
     //reset css classes
-    for (let i = 0; i < plans.length; i++) {
+    for (let i = 0; i < minLegs; i++) {
         resetCssClassesForPlanEntries(plans[i]);
         resetCssClassesForPlanEntries(defaultPlans[i]);
     }
@@ -37,22 +38,23 @@ export function comparePlans() {
     if (plans.length != defaultPlans.length) {
         if (plans.length >= defaultPlans.length) {
             alert("Error: There are more queries in the batch than in the default plans.")
-            return
+
         } else {
             alert("Error: There are more queries in the default plan than in the batch.")
-            return
+
         }
     }
 
     // TEST: Mutation of cssClasses
     // iterate over all plans
-    for (let planIndex = 0; planIndex < plans.length; planIndex++) {
+    for (let planIndex = 0; planIndex < minLegs; planIndex++) {
 
         let currentPlan: Plan = plans[planIndex];
         let currentDefaultPlan: Plan = defaultPlans[planIndex];
 
+        let minItineraries = Math.min(currentPlan.itineraries.length, currentDefaultPlan.itineraries.length);
         // iterate over all itineraries of a plan
-        for (let itineraryIndex = 0; itineraryIndex < currentPlan.itineraries.length; itineraryIndex++) {
+        for (let itineraryIndex = 0; itineraryIndex < minItineraries; itineraryIndex++) {
 
             let currentItinerary = currentPlan.itineraries[itineraryIndex];
             let currentDefaultItinerary = currentDefaultPlan.itineraries[itineraryIndex];

--- a/visual-debugger/src/lib/components/ui/ConnectionDetail.svelte
+++ b/visual-debugger/src/lib/components/ui/ConnectionDetail.svelte
@@ -8,7 +8,7 @@
     import Route from '@/components/ui/Route.svelte';
     import {getModeName} from '$lib/getModeName';
     import {t} from '$lib/i18n/translation';
-    import type {ItineraryShadow} from "@data/type-declarations/comparisonShadows.ts";
+    import {type ItineraryShadow, LegShadow} from "@data/type-declarations/comparisonShadows.ts";
     import MatchIndicator from "@/components/ui/subcomponents/MatchIndicator.svelte";
 
     const {
@@ -38,10 +38,11 @@
     scheduledTimestamp: string,
     isRealtime: boolean,
     name: string,
+    shadowAttribute: boolean,
     stopId?: string
         )}
     <div class="flex items-center">
-        <MatchIndicator attribute="{shadowItinerary.startTime}"></MatchIndicator>
+        <MatchIndicator attribute={shadowAttribute}></MatchIndicator>
         <Time
                 variant="schedule"
                 class="font-semibold w-16"
@@ -59,7 +60,7 @@
     </div>
     {#if stopId}
         <div class="flex items-center">
-            <MatchIndicator attribute="{shadowItinerary}"/>
+            <MatchIndicator attribute={shadowAttribute}/>
             <Button
                     class="text-[length:inherit] justify-normal text-wrap text-left"
                     variant="link"
@@ -137,13 +138,14 @@
                         l.scheduledStartTime,
                         l.realTime,
                         l.from.name,
+                        shadowItinerary.legs[i].startTime,
                         l.from.stopId
                     )}
                 </div>
                 <div class="mt-2 flex items-center text-muted-foreground leading-none">
                     <div class="flex items-center">
                         <div class="flex items-center">
-                            <MatchIndicator attribute={shadowLeg.headsign}/>
+                            <MatchIndicator attribute={shadowItinerary.legs[i].headsign}/>
                             <ArrowRight class="stroke-muted-foreground h-4 w-4"/>
                             <span class="ml-1">{l.headsign}</span>
                         </div>
@@ -177,7 +179,7 @@
                         </summary>
                         <div class="flex mb-1 grid gap-y-4 items-center">
                             {#each l.intermediateStops! as s}
-                                {@render stopTimes(s.arrival!, s.scheduledArrival!, l.realTime, s.name!, s.stopId)}
+                                {@render stopTimes(s.arrival!, s.scheduledArrival!, l.realTime, s.name!, shadowItinerary.legs[i].endTime,s.stopId)} //TODO: change shadow to Intermediate stop arrival time boolean
                             {/each}
                         </div>
                     </details>
@@ -190,6 +192,7 @@
                             l.scheduledEndTime!,
                             l.realTime!,
                             l.to.name,
+                            shadowItinerary.legs[i].endTime,
                             l.to.stopId
                             )}
                     </div>
@@ -209,13 +212,14 @@
                         l.scheduledStartTime,
                         l.realTime,
                         l.from.name,
+                        shadowItinerary.legs[i].startTime,
                         l.from.stopId
                     )}
                 </div>
                 {@render streetLeg(l)}
                 {#if !isLast}
                     <div class="grid gap-y-6 grid-cols-[max-content_max-content_auto] items-center pb-4">
-                        {@render stopTimes(l.endTime, l.scheduledEndTime, l.realTime, l.to.name, l.to.stopId)}
+                        {@render stopTimes(l.endTime, l.scheduledEndTime, l.realTime, l.to.name, shadowItinerary.legs[i].endTime, l.to.stopId)}
                     </div>
                 {/if}
             </div>
@@ -234,6 +238,7 @@
                 lastLeg!.scheduledEndTime,
                 lastLeg!.realTime,
                 lastLeg!.to.name,
+                shadowItinerary.legs[shadowItinerary.legs.length - 1].endTime,
                 lastLeg!.to.stopId
                 )}
         </div>


### PR DESCRIPTION
- An unequal number of plans are alerted and the existing ones are compared
- if there is an unequal number of itineraries, the ones that have no counterpart can still be accessed in ConnectionDetail
- if there is an unequal number of legs, all of them are shown in detailed view and the ones without a counterpart are displayed as non-matching

Closes #69 

## Checklist

#### Formalities:
- [x] PR targets `staging`, if compare branch is `chore/*` or `feat/*`
- [x] PR title is formatted as a [commit](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] ~~New functions are commented in the source file~~
- [ ] ~~Notes are added to wiki~~

#### Quality assurance:
- Manual build and unit/component testing:
    - [x] Linux
    - [x] macOS
    - [x] Windows
- Manual End-To-End testing:
    - [x] Upload of query batch
    - [x] Computation of routing results
    - [x] Download plan
    - [x] Upload plan
    - [x] Compare functionality

#### For `staging -> master`
- [ ] ~~Check for relevant open issues~~
- [ ] ~~After merge: Create release~~

---
