### PR TITLE
feat: correct behavior on screen size change

### DIFF
--- a/visual-debugger/src/lib/components/ui/subcomponents/MatchIndicator.svelte
+++ b/visual-debugger/src/lib/components/ui/subcomponents/MatchIndicator.svelte
@@ -3,11 +3,11 @@
 </script>
 
 {#if attribute}
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none"
          stroke="#26a269" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
          class="lucide lucide-check"><path d="M20 6 9 17l-5-5"/></svg>
 {:else}
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
+    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none"
          stroke="#a51d2d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
          class="lucide lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
 {/if}

--- a/visual-debugger/src/lib/components/ui/subcomponents/PlanEntry.svelte
+++ b/visual-debugger/src/lib/components/ui/subcomponents/PlanEntry.svelte
@@ -26,7 +26,7 @@
     <div class="m-1">
         <span class="font-bold">Itinerary Index: {itinerary.index}</span>
         <Separator class="bg-black m-2"></Separator>
-        <div class="grid grid-cols-6 grid-rows-2 gap-1 w-full">
+        <div class="grid grid-cols-6 grid-rows-2 gap-1 w-full text-sm lg:text-base">
             <div class="col-span-2 grid grid-cols-7 content-center">
                 <div class="col-span-1 content-center">
                     <MatchIndicator attribute={evalItinerary(itinerary.index).startTime}/>

--- a/visual-debugger/src/routes/+page.svelte
+++ b/visual-debugger/src/routes/+page.svelte
@@ -30,19 +30,20 @@
 
 </script>
 <!-- Container and flex logic from https://tailwindcss.com/docs/container -->
-<div class="h-screen w-screen my-4 flex flex-col flex-none">
+<div class="h-screen w-screen my-4 flex flex-col">
 
     <!-- Header -->
-    <div class="h-1/6 w-full flex flex-row gap-2 px-4">
+    <div class="md:h-1/6 w-full flex flex-col md:flex-row gap-2 px-4">
 
         <!-- Logo & Dark Mode -->
-        <div class="basis-1/4 flex flex-row flex-none h-full">
+        <div class="basis-full md:basis-1/2 flex flex-row md:place-content-start justify-center">
 
-            <div class="basis-1/2 flex-none h-full p-7">
-                <img src="/logo_clipped.svg" alt="MoViDe logo" class="w-full h-full">
+            <div class="h-32 md:h-full p-4 content-start">
+                <img src="/logo_clipped.svg" alt="MoViDe logo" class="h-full">
             </div>
-
-            <div class="basis-1/2 content-center">
+            
+            <div class="content-center">
+                
                 <Button on:click={toggleMode} variant="outline" size="icon">
                     <Sun
                             class="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
@@ -57,7 +58,7 @@
 
 
         <!-- File handling -->
-        <div class="basis-3/4 flex flex-row-reverse gap-2 items-center">
+        <div class="basis-full md:basis-1/2 flex flex-row flex-row-reverse gap-2 items-center md:place-content-end justify-center">
             <div class="flex flex-col gap-2">
                 <Button on:click={computePlansInterface}>Compute routing</Button>
                 <Button variant="default" on:click={downloadPlanInterface}>Download data as default plan</Button>
@@ -72,9 +73,10 @@
     </div>
 
     <!-- Main content -->
-    <div class="h-5/6 w-full my-4 flex">
+    <div class="h-5/6 w-full my-2 md:flex md:flex-row">
 
-        <div class="basis-1/3 grid grid-rows-12">
+        <!-- Query Batches: Grid layout scheint die einzige Option zu sein shadcn scroll box zu kontrollieren -->
+        <div class="basis-full md:basis-1/3 grid grid-rows-12">
 
             <div class="p-2 row-span-1 content-end">
                 <h1 class="text-xl">Query Batch Overview</h1>
@@ -87,12 +89,12 @@
         </div>
 
         <!-- Comparisons -->
-        <div class="basis-2/3 grid grid-rows-12 grid-cols-2 gap-2">
+        <div class="basis-full h-5/6 md:h-full md:basis-2/3 grid grid-rows-12 grid-cols-2">
 
             <!-- Filtering options -->
             <div class="col-span-2 row-span-1 flex justify-center items-center">
                 <div class="flex flex-row items-center gap-4">
-                    Filter options:
+                    Plan Filter options:
                     <div class="flex items-center">
                         <Checkbox id="filter2" bind:checked={$showMismatchedStore}
                                   on:click={() => $showMismatchedStore ? filterOutMatched() : resetItinerariesWithFilterMismatched($showMatchedStore)}/>


### PR DESCRIPTION
<!-- List of changes as bullet points or free form text -->
- Added how the layout should respond to different screen sizes
- slightly reduced the logo size of X and ✓ to not use too much space when reducing screen size
- planEntry.svelte now reduces text size if scaled down


closes #28 
closes #29

## Checklist

#### Formalities:
- [x] PR targets `staging`, if compare branch is `chore/*` or `feat/*`
- [x] PR title is formatted as a [commit](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [x] New functions are commented in the source file
- [x] Notes are added to wiki

#### Quality assurance:
- Manual build and unit/component testing:
    - [x] Linux
    - [x] macOS
    - [x] Windows
- Manual End-To-End testing:
    - [x] Upload of query batch
    - [x] Computation of routing results
    - [x] Download plan
    - [x] Upload plan
    - [x] Compare functionality
    - [x] Itinerary Overview 

#### For `staging -> master`
- [x] Check for relevant open issues
- [x] After merge: Create release

---
